### PR TITLE
Add parameterization to @httpMalformedRequestTests

### DIFF
--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestCase.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestCase.java
@@ -18,11 +18,6 @@ package software.amazon.smithy.protocoltests.traits;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import software.amazon.smithy.model.node.ArrayNode;
-import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.ObjectNode;
-import software.amazon.smithy.model.node.StringNode;
-import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.utils.ListUtils;
@@ -33,15 +28,12 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 /**
  * Defines a test case for malformed HTTP requests.
  */
-public final class HttpMalformedRequestTestCase
-        implements Tagged, ToNode, ToSmithyBuilder<HttpMalformedRequestTestCase> {
+public final class HttpMalformedRequestTestCase implements Tagged, ToSmithyBuilder<HttpMalformedRequestTestCase> {
 
-    private static final String DOCUMENTATION = "documentation";
     private static final String ID = "id";
     private static final String PROTOCOL = "protocol";
     private static final String REQUEST = "request";
     private static final String RESPONSE = "response";
-    private static final String TAGS = "tags";
 
     private final String documentation;
     private final String id;
@@ -84,33 +76,6 @@ public final class HttpMalformedRequestTestCase
         return tags;
     }
 
-    public static HttpMalformedRequestTestCase fromNode(Node node) {
-        HttpMalformedRequestTestCase.Builder builder = builder();
-        ObjectNode o = node.expectObjectNode();
-        o.getStringMember(DOCUMENTATION).map(StringNode::getValue).ifPresent(builder::documentation);
-        builder.id(o.expectStringMember(ID).getValue());
-        builder.protocol(o.expectStringMember(PROTOCOL).expectShapeId());
-        builder.request(HttpMalformedRequestDefinition.fromNode(o.expectObjectMember(REQUEST)));
-        builder.response(HttpMalformedResponseDefinition.fromNode(o.expectObjectMember(RESPONSE)));
-        o.getArrayMember(TAGS).ifPresent(tags -> {
-            builder.tags(tags.getElementsAs(StringNode::getValue));
-        });
-        return builder.build();
-    }
-
-    @Override
-    public Node toNode() {
-        return Node.objectNodeBuilder()
-                .withOptionalMember(DOCUMENTATION, getDocumentation().map(Node::from))
-                .withMember(ID, getId())
-                .withMember(PROTOCOL, getProtocol().toString())
-                .withMember(REQUEST, getRequest().toNode())
-                .withMember(RESPONSE, getResponse().toNode())
-                .withOptionalMember(TAGS,
-                        tags.isEmpty() ? Optional.empty() : Optional.of(ArrayNode.fromStrings(getTags())))
-                .build();
-    }
-
     @Override
     public Builder toBuilder() {
         Builder builder = builder()
@@ -128,7 +93,7 @@ public final class HttpMalformedRequestTestCase
     }
 
     /**
-     * Builder used to create a HttpRequestTestsTrait.
+     * Builder used to create a HttpMalformedRequestTestCase.
      */
     public static final class Builder implements SmithyBuilder<HttpMalformedRequestTestCase> {
 

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestsValidator.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/HttpMalformedRequestTestsValidator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.protocoltests.traits;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Ensures that parameters attached to @httpMalformedRequestTest cases are well-formed.
+ */
+@SmithyInternalApi
+public final class HttpMalformedRequestTestsValidator extends AbstractValidator {
+
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        List<ValidationEvent> events = new ArrayList<>();
+        Stream.concat(model.shapes(OperationShape.class), model.shapes(StructureShape.class)).forEach(shape -> {
+            shape.getTrait(HttpMalformedRequestTestsTrait.class).ifPresent(trait -> {
+                trait.getParameterizedTestCases().forEach(testCase -> {
+                    if (!testCase.getTestParameters().isEmpty()) {
+                        Set<Integer> sizes = testCase.getTestParameters().values()
+                                .stream().map(List::size).collect(Collectors.toSet());
+                        if (sizes.size() != 1) {
+                            events.add(error(shape, trait.getSourceLocation(), "Each list associated to a key "
+                                    + "in `testParameters` must be of the same length."));
+                        }
+                    }
+                });
+            });
+        });
+        return events;
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ParameterizedHttpMalformedRequestTestCase.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/ParameterizedHttpMalformedRequestTestCase.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.protocoltests.traits;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.node.ToNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ToShapeId;
+import software.amazon.smithy.utils.CodeWriter;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.Tagged;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+/**
+ * Defines a parameterized test case for malformed HTTP requests.
+ *
+ * This class is *not* preferred for code generation - use {@link HttpMalformedRequestTestCase}
+ * instances instead, retrieved from {@link HttpMalformedRequestTestsTrait#getTestCases()}.
+ */
+final class ParameterizedHttpMalformedRequestTestCase
+        implements Tagged, ToNode, ToSmithyBuilder<ParameterizedHttpMalformedRequestTestCase> {
+
+    private static final String DOCUMENTATION = "documentation";
+    private static final String ID = "id";
+    private static final String PROTOCOL = "protocol";
+    private static final String REQUEST = "request";
+    private static final String RESPONSE = "response";
+    private static final String TAGS = "tags";
+    private static final String TEST_PARAMETERS = "testParameters";
+
+    private final String documentation;
+    private final String id;
+    private final ShapeId protocol;
+    private final HttpMalformedRequestDefinition request;
+    private final HttpMalformedResponseDefinition response;
+    private final List<String> tags;
+    private final Map<String, List<String>> testParameters;
+
+    private ParameterizedHttpMalformedRequestTestCase(Builder builder) {
+        documentation = builder.documentation;
+        id = SmithyBuilder.requiredState(ID, builder.id);
+        protocol = SmithyBuilder.requiredState(PROTOCOL, builder.protocol);
+        request = SmithyBuilder.requiredState(REQUEST, builder.request);
+        response = SmithyBuilder.requiredState(RESPONSE, builder.response);
+        tags = ListUtils.copyOf(builder.tags);
+        testParameters = MapUtils.copyOf(builder.testParameters);
+    }
+
+    public Optional<String> getDocumentation() {
+        return Optional.ofNullable(documentation);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public ShapeId getProtocol() {
+        return protocol;
+    }
+
+    public HttpMalformedRequestDefinition getRequest() {
+        return request;
+    }
+
+    public HttpMalformedResponseDefinition getResponse() {
+        return response;
+    }
+
+    @Override
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public Map<String, List<String>> getTestParameters() {
+        return testParameters;
+    }
+
+    public List<HttpMalformedRequestTestCase> generateTestCasesFromParameters() {
+        if (testParameters.isEmpty()) {
+            HttpMalformedRequestTestCase.Builder builder = HttpMalformedRequestTestCase.builder()
+                    .id(getId())
+                    .protocol(getProtocol())
+                    .request(request)
+                    .response(response)
+                    .tags(getTags());
+            getDocumentation().ifPresent(builder::documentation);
+            return ListUtils.of(builder.build());
+        }
+
+        int paramLength = testParameters.values().stream().findFirst().map(List::size)
+                .orElseThrow(IllegalStateException::new);
+        final List<HttpMalformedRequestTestCase> testCases = new ArrayList<>(paramLength);
+        for (int i = 0; i < paramLength; i++) {
+            final CodeWriter cw = new CodeWriter();
+            for (Map.Entry<String, List<String>> e : testParameters.entrySet()) {
+                cw.putContext(e.getKey(), e.getValue().get(i));
+            }
+
+            HttpMalformedRequestTestCase.Builder builder = HttpMalformedRequestTestCase.builder()
+                    .id(String.format(getId() + "_case%d", i))
+                    .protocol(getProtocol())
+                    .tags(getTags());
+            getDocumentation().map(cw::format).ifPresent(builder::documentation);
+
+            testCases.add(builder.request(interpolateRequest(request, cw))
+                                 .response(interpolateResponse(response, cw))
+                                 .build());
+        }
+        return testCases;
+    }
+
+    private static HttpMalformedResponseDefinition interpolateResponse(HttpMalformedResponseDefinition response,
+                                                                       CodeWriter cw) {
+        HttpMalformedResponseDefinition.Builder responseBuilder =
+                response.toBuilder().headers(formatHeaders(cw, response.getHeaders()));
+        response.getBody()
+                .map(responseBody -> {
+                    HttpMalformedResponseBodyDefinition.Builder bodyBuilder = responseBody.toBuilder()
+                            .mediaType(cw.format(responseBody.getMediaType()));
+                    responseBody.getContents().map(cw::format).ifPresent(bodyBuilder::contents);
+                    responseBody.getMessageRegex().map(cw::format).ifPresent(bodyBuilder::messageRegex);
+                    return bodyBuilder.build();
+                })
+                .ifPresent(responseBuilder::body);
+        return responseBuilder.build();
+    }
+
+    private static HttpMalformedRequestDefinition interpolateRequest(HttpMalformedRequestDefinition request,
+                                                                     CodeWriter cw) {
+        HttpMalformedRequestDefinition.Builder requestBuilder = request.toBuilder()
+                .headers(formatHeaders(cw, request.getHeaders()))
+                .queryParams(request.getQueryParams().stream().map(cw::format).collect(Collectors.toList()));
+        request.getBody().map(cw::format).ifPresent(requestBuilder::body);
+        request.getUri().map(cw::format).ifPresent(requestBuilder::uri);
+        return requestBuilder.build();
+    }
+
+    private static Map<String, String> formatHeaders(CodeWriter cw, Map<String, String> headers) {
+        Map<String, String> newHeaders = new HashMap<>();
+        for (Map.Entry<String, String> headerEntry : headers.entrySet()) {
+            newHeaders.put(cw.format(headerEntry.getKey()), cw.format(headerEntry.getValue()));
+        }
+        return newHeaders;
+    }
+
+    public static ParameterizedHttpMalformedRequestTestCase fromNode(Node node) {
+        ParameterizedHttpMalformedRequestTestCase.Builder builder = builder();
+        ObjectNode o = node.expectObjectNode();
+        o.getStringMember(DOCUMENTATION).map(StringNode::getValue).ifPresent(builder::documentation);
+        builder.id(o.expectStringMember(ID).getValue());
+        builder.protocol(o.expectStringMember(PROTOCOL).expectShapeId());
+        builder.request(HttpMalformedRequestDefinition.fromNode(o.expectObjectMember(REQUEST)));
+        builder.response(HttpMalformedResponseDefinition.fromNode(o.expectObjectMember(RESPONSE)));
+        o.getArrayMember(TAGS).ifPresent(tags -> {
+            builder.tags(tags.getElementsAs(StringNode::getValue));
+        });
+        o.getObjectMember(TEST_PARAMETERS).ifPresent(params -> {
+            Map<String, List<String>> paramsMap = new HashMap<>();
+            for (Map.Entry<String, Node> e : params.getStringMap().entrySet()) {
+                paramsMap.put(e.getKey(),
+                              e.getValue().expectArrayNode().getElementsAs(n -> n.expectStringNode().getValue()));
+            }
+            builder.testParameters(paramsMap);
+        });
+        return builder.build();
+    }
+
+    @Override
+    public Node toNode() {
+        ObjectNode.Builder builder = Node.objectNodeBuilder()
+                .withOptionalMember(DOCUMENTATION, getDocumentation().map(Node::from))
+                .withMember(ID, getId())
+                .withMember(PROTOCOL, getProtocol().toString())
+                .withMember(REQUEST, getRequest().toNode())
+                .withMember(RESPONSE, getResponse().toNode());
+
+        if (!tags.isEmpty()) {
+            builder.withMember(TAGS, ArrayNode.fromStrings(getTags()));
+        }
+        if (!testParameters.isEmpty()) {
+            ObjectNode.Builder paramBuilder = ObjectNode.objectNodeBuilder();
+            for (Map.Entry<String, List<String>> e : getTestParameters().entrySet()) {
+                paramBuilder.withMember(e.getKey(), ArrayNode.fromStrings(e.getValue()));
+            }
+            builder.withMember(TEST_PARAMETERS, paramBuilder.build());
+        }
+        return builder.build();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        Builder builder = builder()
+                .id(getId())
+                .protocol(getProtocol())
+                .request(getRequest())
+                .response(getResponse())
+                .tags(getTags())
+                .testParameters(getTestParameters());
+        getDocumentation().ifPresent(builder::documentation);
+        return builder;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder used to create a ParameterizedHttpMalformedRequestTestCase.
+     */
+    public static final class Builder implements SmithyBuilder<ParameterizedHttpMalformedRequestTestCase> {
+
+        private String documentation;
+        private String id;
+        private ShapeId protocol;
+        private HttpMalformedRequestDefinition request;
+        private HttpMalformedResponseDefinition response;
+        private final List<String> tags = new ArrayList<>();
+        private final Map<String, List<String>> testParameters = new HashMap<>();
+
+        private Builder() {}
+
+        public Builder documentation(String documentation) {
+            this.documentation = documentation;
+            return this;
+        }
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder protocol(ToShapeId protocol) {
+            this.protocol = protocol.toShapeId();
+            return this;
+        }
+
+        public Builder request(HttpMalformedRequestDefinition request) {
+            this.request = request;
+            return this;
+        }
+
+        public Builder response(HttpMalformedResponseDefinition response) {
+            this.response = response;
+            return this;
+        }
+
+        public Builder tags(List<String> tags) {
+            this.tags.clear();
+            this.tags.addAll(tags);
+            return this;
+        }
+
+        public Builder testParameters(Map<String, List<String>> testParameters) {
+            this.testParameters.clear();
+            this.testParameters.putAll(testParameters);
+            return this;
+        }
+
+        @Override
+        public ParameterizedHttpMalformedRequestTestCase build() {
+            return new ParameterizedHttpMalformedRequestTestCase(this);
+        }
+    }
+}

--- a/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/UniqueProtocolTestCaseIdValidator.java
+++ b/smithy-protocol-test-traits/src/main/java/software/amazon/smithy/protocoltests/traits/UniqueProtocolTestCaseIdValidator.java
@@ -50,6 +50,8 @@ public class UniqueProtocolTestCaseIdValidator extends AbstractValidator {
                     .ifPresent(trait -> addTestCaseIdsToMap(shape, trait.getTestCases(), requestIdsToTraits));
             shape.getTrait(HttpResponseTestsTrait.class)
                     .ifPresent(trait -> addTestCaseIdsToMap(shape, trait.getTestCases(), responseIdsToTraits));
+            // This deliberately uses the expanded, instead of parameterized test cases,
+            // in case someone does something wild with naming, like add _case0 to the end of the id
             shape.getTrait(HttpMalformedRequestTestsTrait.class)
                     .ifPresent(t -> addMalformedRequestTestCaseIdsToMap(shape, t.getTestCases(), responseIdsToTraits));
         });

--- a/smithy-protocol-test-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/smithy-protocol-test-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -2,3 +2,4 @@ software.amazon.smithy.protocoltests.traits.HttpRequestTestsInputValidator
 software.amazon.smithy.protocoltests.traits.HttpResponseTestsOutputValidator
 software.amazon.smithy.protocoltests.traits.HttpResponseTestsErrorValidator
 software.amazon.smithy.protocoltests.traits.UniqueProtocolTestCaseIdValidator
+software.amazon.smithy.protocoltests.traits.HttpMalformedRequestTestsValidator

--- a/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
+++ b/smithy-protocol-test-traits/src/main/resources/META-INF/smithy/smithy.test.smithy
@@ -322,6 +322,9 @@ structure HttpMalformedRequestTestCase {
 
     /// Applies a list of tags to the test.
     tags: NonEmptyStringList,
+
+    /// An optional set of test parameters for parameterized testing.
+    testParameters: HttpMalformedRequestTestParametersDefinition,
 }
 
 @private
@@ -378,6 +381,7 @@ structure HttpMalformedResponseDefinition {
     body: HttpMalformedResponseBodyDefinition,
 }
 
+@private
 structure HttpMalformedResponseBodyDefinition {
     /// The assertion to execute against the response body.
     @required
@@ -391,6 +395,7 @@ structure HttpMalformedResponseBodyDefinition {
     mediaType: String
 }
 
+@private
 union HttpMalformedResponseBodyAssertion {
     /// Defines the expected serialized response body, which will be matched
     /// exactly.
@@ -400,4 +405,10 @@ union HttpMalformedResponseBodyAssertion {
     /// responses that may have some variance from platform to platform,
     /// such as those that include messages from a parser.
     messageRegex: String
+}
+
+@private
+map HttpMalformedRequestTestParametersDefinition {
+    key: String,
+    value: StringList
 }

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/all-malformed-request-features.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/all-malformed-request-features.smithy
@@ -76,6 +76,28 @@ structure testProtocol {}
             headers: {"X-Foo": "baz"}
         },
         tags: ["foo", "bar"]
+    },
+    {
+        id: "parameterized",
+        documentation: "Testing...",
+        protocol: testProtocol,
+        request: {
+            body: "$foo:L",
+            headers: {"X-Foo": "baz"},
+            host: "example.com",
+            method: "POST",
+            uri: "/",
+            queryParams: ["foo=baz"]
+        },
+        response: {
+            code: 400,
+            headers: {"X-Foo": "$bar:L"}
+        },
+        tags: ["foo", "bar"],
+        testParameters: {
+            "foo" : ["a", "b", "c"],
+            "bar" : ["d", "e", "f"]
+        }
     }
 ])
 operation SayHello {

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-malformed-request-parameters.errors
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-malformed-request-parameters.errors
@@ -1,0 +1,1 @@
+[ERROR] smithy.example#SayHello: Each list associated to a key in `testParameters` must be of the same length. | HttpMalformedRequestTests

--- a/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-malformed-request-parameters.smithy
+++ b/smithy-protocol-test-traits/src/test/resources/software/amazon/smithy/protocoltests/traits/errorfiles/detects-invalid-malformed-request-parameters.smithy
@@ -1,0 +1,50 @@
+namespace smithy.example
+
+use smithy.test#httpMalformedRequestTests
+
+@trait
+@protocolDefinition
+structure testProtocol {}
+
+@http(method: "POST", uri: "/")
+@httpMalformedRequestTests([
+    {
+        id: "definesMismatchedTestParameters",
+        documentation: "Testing...",
+        protocol: testProtocol,
+        request: {
+            body: "$foo:L",
+            headers: {"X-Foo": "baz"},
+            host: "example.com",
+            method: "POST",
+            uri: "/",
+            queryParams: ["foo=baz"]
+        },
+        response: {
+            code: 400,
+            headers: {"X-Foo": "baz"},
+            body: {
+                assertion: {
+                    messageRegex: "Invalid JSON: $bar:L"
+                },
+                mediaType: "application/json"
+            }
+        },
+        tags: ["foo", "bar"],
+        testParameters: {
+            foo: ["a", "b", "c"],
+            bar: ["d", "e"]
+        }
+    }
+])
+operation SayHello {
+    input: SayHelloInput
+}
+
+structure SayHelloInput {
+    @httpPayload
+    body: String,
+
+    @httpHeader("X-OmitMe")
+    header: String,
+}


### PR DESCRIPTION
*Description of changes:*
As an opt-in feature of @httpMalformedRequestTests, test authors can use the
testParameters field to create parameterized tests, for testing multiple
instances of the same kind of bad input, such as multiple forms of invalid
booleans. The expansion of these test cases is performed within the trait,
and code generators are not exposed to the parameterized test cases at any
point.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
